### PR TITLE
Changed text to specify wav file on upload page

### DIFF
--- a/client/src/components/pages/Upload.js
+++ b/client/src/components/pages/Upload.js
@@ -143,7 +143,7 @@ function Upload() {
       <Form enctype="multipart/form-data">
         <Form.Group controlId="formFile" class="col-lg-6 offset-lg-3">
           <div className="row justify-content-center">
-            <Form.Label>Upload your data</Form.Label>
+            <Form.Label>Upload your Wav File</Form.Label>
             <Form.Control
               type="file"
               style={{ width: "50%" }}


### PR DESCRIPTION
Text used to say "Upload your data". It is now changed to say "Upload your Wav File" as the site only supports the editing of wav files.